### PR TITLE
Use conv2_1 layer instead of conv3_1 for sem2_1 input

### DIFF
--- a/doodle.py
+++ b/doodle.py
@@ -128,7 +128,7 @@ class Model(object):
         net['map_3'] = PoolLayer(net['map'], 4, mode='average_exc_pad')
         net['map_4'] = PoolLayer(net['map'], 8, mode='average_exc_pad')
 
-        net['sem2_1'] = ConcatLayer([net['conv3_1'], net['map_2']])
+        net['sem2_1'] = ConcatLayer([net['conv2_1'], net['map_2']])
         net['sem3_1'] = ConcatLayer([net['conv3_1'], net['map_3']])
         net['sem4_1'] = ConcatLayer([net['conv4_1'], net['map_4']])
 


### PR DESCRIPTION
In the paper describing the neural doodle architecture, it has sem2_1 doing concatenation with conv2_1 as its input, not conv3_1 as in the current master branch.
